### PR TITLE
cygwin: package names for mingw64-*-gcc changed

### DIFF
--- a/scripts/functions/requirements/cygwin
+++ b/scripts/functions/requirements/cygwin
@@ -56,7 +56,7 @@ requirements_cygwin_define()
     (*)
       requirements_check libiconv zlib zlib-devel openssl openssl-devel \
         libyaml-devel libyaml0_2 sqlite3 make libtool gcc gcc-core \
-        autoconf automake bison m4 mingw64-i686-gcc mingw64-x86_64-gcc \
+        autoconf automake bison m4 mingw64-i686-gcc-core mingw64-x86_64-gcc-core \
         patch
       if [[ "${_system_arch}" == "x86_64" ]]
       then requirements_check cygwin32-readline


### PR DESCRIPTION
The packages `mingw64-i686-gcc` and `mingw64-x86_64-gcc` got renamed and received a `-core` extension and are now called `mingw64-i686-gcc-core` and `mingw64-x86_64-gcc-core`.

https://cygwin.com/cgi-bin2/package-grep.cgi?grep=mingw64-.*-gcc&arch=x86_64
